### PR TITLE
feat: add `streaming` to `map_batches`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ authors = [
     { name = "Minghua Zhang" },
     { name = "Zhewen Hao" },
 ]
+readme = "README.md"
 urls = { Homepage = "https://github.com/deepseek-ai/smallpond" }
 keywords = ["distributed query processing", "SQL", "parquet"]
 requires-python = ">=3.8"

--- a/smallpond/dataframe.py
+++ b/smallpond/dataframe.py
@@ -598,8 +598,13 @@ class DataFrame:
         """
 
         if streaming:
-            def process_func(_runtime_ctx, readers: List[arrow.RecordBatchReader]) -> Iterator[arrow.Table]:
-                tables = map(lambda batch: arrow.Table.from_batches([batch]), readers[0])
+
+            def process_func(
+                _runtime_ctx, readers: List[arrow.RecordBatchReader]
+            ) -> Iterator[arrow.Table]:
+                tables = map(
+                    lambda batch: arrow.Table.from_batches([batch]), readers[0]
+                )
                 return func(tables)
 
             plan = ArrowStreamNode(
@@ -610,6 +615,7 @@ class DataFrame:
                 **kwargs,
             )
         else:
+
             def process_func(_runtime_ctx, tables: List[arrow.Table]) -> arrow.Table:
                 return func(tables[0])
 


### PR DESCRIPTION
This PR introduces a `streaming` option to the `map_batches` function. When `streaming=true`, the user function will receive an iterator and return an iterator. This enables users to customize the streaming logic for data processing, such as parallelizing CPU and GPU operations to improve utilization of both resources. However, this approach is still not straightforward enough for users. In the future, we plan to allow users to pass multiple functions, which will automatically be executed in parallel across different threads in a pipelined manner.