### PR TITLE
fix: move setuptools-scm from optional to dependencies since we need it for distutils #13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "fsspec >= 2023.12.2",
     "ray[default] >= 2.10.0",
     "graphviz >= 0.19.1",
+    "setuptools-scm==8.1.0",
 ]
 
 [project.optional-dependencies]
@@ -52,7 +53,6 @@ dev = [
     "pytest-benchmark==4.0.0",
     "setproctitle==1.3.3",
     "soupsieve~=2.5",
-    "setuptools-scm==8.1.0",
     "packaging==24.2",
     "jaraco.functools==4.1.0",
 ]


### PR DESCRIPTION
fix: move setuptools-scm from optional to dependencies since we need t for distutils #13

fix: #13 