### PR TITLE
Add DeltaLake source support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ dependencies = [
     "GPUtil >= 1.4.0",
     "py-libnuma >= 1.2",
     "fsspec >= 2023.12.2",
-    "ray[default] >= 2.10.0",
+    "ray[default]>=2.10.0",
     "graphviz >= 0.19.1",
+    "deltalake >= 0.15.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "GPUtil >= 1.4.0",
     "py-libnuma >= 1.2",
     "fsspec >= 2023.12.2",
-    "ray[default]>=2.10.0",
+    "ray[default] >= 2.10.0",
     "graphviz >= 0.19.1",
     "deltalake >= 0.15.0",
 ]

--- a/smallpond/dataframe.py
+++ b/smallpond/dataframe.py
@@ -12,6 +12,7 @@ import pyarrow as arrow
 import ray
 import ray.exceptions
 from loguru import logger
+from deltalake import DeltaTable
 
 from smallpond.execution.task import Task
 from smallpond.io.filesystem import remove_path
@@ -53,6 +54,25 @@ class Session(SessionBase):
         """
         Create a DataFrame from Parquet files.
         """
+        dataset = ParquetDataSet(paths, columns=columns, union_by_name=union_by_name, recursive=recursive)
+        plan = DataSourceNode(self._ctx, dataset)
+        return DataFrame(self, plan)
+    
+
+    def read_deltalake(
+        self,
+        path: str,
+        recursive: bool = False,
+        columns: Optional[List[str]] = None,
+        union_by_name: bool = False,
+    ) -> DataFrame:
+        """
+        Create a DataFrame from DeltaLake Parquet files.
+        """
+        if 's3://' in path or 'gs://' in path:
+            raise ValueError("DeltaLake on S3 and GS is not supported yet.")
+        dt = DeltaTable(path)
+        paths = dt.files()
         dataset = ParquetDataSet(paths, columns=columns, union_by_name=union_by_name, recursive=recursive)
         plan = DataSourceNode(self._ctx, dataset)
         return DataFrame(self, plan)

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -3,6 +3,7 @@ from typing import List
 import pandas as pd
 import pyarrow as pa
 import pytest
+from deltalake.writer import write_deltalake
 
 from smallpond.dataframe import Session
 
@@ -40,8 +41,10 @@ def test_parquet(sp: Session):
     assert df.count() == 1000
 
 def test_read_deltalake(sp: Session):
+    sample = sp.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    write_deltalake("tests/data/", sample)
     df = sp.read_deltalake("tests/data/")
-    assert df.count() == 4
+    assert df.count() == 3
 
 
 def test_take(sp: Session):

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -39,6 +39,10 @@ def test_parquet(sp: Session):
     df = sp.read_parquet("tests/data/mock_urls/*.parquet")
     assert df.count() == 1000
 
+def test_read_deltalake(sp: Session):
+    df = sp.read_deltalake("tests/data/")
+    assert df.count() == 4
+
 
 def test_take(sp: Session):
     df = sp.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -41,7 +41,7 @@ def test_parquet(sp: Session):
     assert df.count() == 1000
 
 def test_read_deltalake(sp: Session):
-    sample = sp.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    sample = pd.DataFrame({"x": [1, 2, 3]})
     write_deltalake("tests/data/", sample)
     df = sp.read_deltalake("tests/data/")
     assert df.count() == 3


### PR DESCRIPTION
Add a new method called `read_deltalake()`. Simply read the Delta Lake table and get the list of parquet files for that Delta Lake table so we can reuse `ParquetDataSet`. (doing this by calling `dt.files()` which returns a list of parquet files).