### PR TITLE
fix: Add setuptools as runtime dependency for Python 3.12+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires-python = ">=3.8"
 dependencies = [
     "duckdb >= 1.2.0",
     "pyarrow ~= 16.1.0",
+    "setuptools >= 65.0.0",  # Required for Python 3.12+ (distutils compatibility)
     "polars ~= 0.20.9",
     "pandas >= 1.3.4",
     "plotly >= 5.22.0",


### PR DESCRIPTION
## Summary

- Adds `setuptools >= 65.0.0` to runtime dependencies to fix Python 3.12+ compatibility
- Resolves `ModuleNotFoundError: No module named 'distutils'` error

## Related Issue

Fixes #13

## Background

The `distutils` module was deprecated in Python 3.10 (PEP 632) and completely removed in Python 3.12. The `setuptools` package provides a compatibility shim that makes `distutils` available for packages and dependencies that still rely on it.

While `setuptools` is already listed as a build-time dependency in `[build-system].requires`, it was not included as a runtime dependency. This caused issues for Python 3.12+ users when running smallpond, as some code paths (possibly from dependencies) still import from `distutils`.

## Changes

Added `setuptools >= 65.0.0` to the `dependencies` list in `pyproject.toml`:

```toml
dependencies = [
    "duckdb >= 1.2.0",
    "pyarrow ~= 16.1.0",
    "setuptools >= 65.0.0",  # Required for Python 3.12+ (distutils compatibility)
    ...
]
```

The minimum version of 65.0.0 was chosen as it includes robust distutils compatibility features.

## Test plan

- [ ] Verify installation succeeds on Python 3.12+
- [ ] Verify `import smallpond` works without `distutils` errors
- [ ] Verify existing functionality is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)