### PR TITLE
fix: handle WSL2 NUMA detection

### DIFF
--- a/smallpond/execution/numa.py
+++ b/smallpond/execution/numa.py
@@ -1,0 +1,18 @@
+import platform
+import sys
+
+
+def running_on_wsl() -> bool:
+    if sys.platform != "linux":
+        return False
+    release = platform.uname().release.lower()
+    return "microsoft" in release or "wsl" in release
+
+
+def get_numa_node_count() -> int:
+    if sys.platform == "darwin" or running_on_wsl():
+        return 1
+
+    import numa
+
+    return max(1, int(numa.info.get_num_configured_nodes()))

--- a/smallpond/execution/task.py
+++ b/smallpond/execution/task.py
@@ -69,6 +69,7 @@ from smallpond.common import (
     round_up,
     split_into_rows,
 )
+from smallpond.execution.numa import get_numa_node_count
 from smallpond.execution.workqueue import WorkItem, WorkStatus
 from smallpond.io.arrow import (
     cast_columns_to_large_string,
@@ -245,12 +246,7 @@ class RuntimeContext(object):
 
     @property
     def numa_node_count(self):
-        if sys.platform == "darwin":
-            # numa is not supported on macos
-            return 1
-        import numa
-
-        return numa.info.get_num_configured_nodes()
+        return get_numa_node_count()
 
     @property
     def physical_cpu_count(self):

--- a/smallpond/worker.py
+++ b/smallpond/worker.py
@@ -7,6 +7,23 @@ import subprocess
 
 import psutil
 
+from smallpond.execution.numa import get_numa_node_count
+
+
+def start_ray_worker(ray_address: str, cpu_count: int, memory: int = None):
+    command = [
+        "ray",
+        "start",
+        "--address",
+        ray_address,
+        "--num-cpus",
+        str(cpu_count),
+    ]
+    if memory is not None:
+        command.extend(["--memory", str(memory)])
+    subprocess.run(command, check=True)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="smallpond worker")
     parser.add_argument(
@@ -29,42 +46,33 @@ if __name__ == "__main__":
     memory = psutil.virtual_memory().total
 
     if args.bind_numa_node:
-        import numa
-
-        numa_node_count = numa.info.get_num_configured_nodes()
-        cpu_count_per_socket = cpu_count // numa_node_count
-        memory_per_socket = memory // numa_node_count
-        for i in range(numa_node_count):
-            subprocess.run(
-                [
-                    "numactl",
-                    "-N",
-                    str(i),
-                    "-m",
-                    str(i),
-                    "ray",
-                    "start",
-                    "--address",
-                    args.ray_address,
-                    "--num-cpus",
-                    str(cpu_count_per_socket),
-                    "--memory",
-                    str(memory_per_socket),
-                ],
-                check=True,
-            )
+        numa_node_count = get_numa_node_count()
+        if numa_node_count == 1:
+            start_ray_worker(args.ray_address, cpu_count, memory)
+        else:
+            cpu_count_per_socket = cpu_count // numa_node_count
+            memory_per_socket = memory // numa_node_count
+            for i in range(numa_node_count):
+                subprocess.run(
+                    [
+                        "numactl",
+                        "-N",
+                        str(i),
+                        "-m",
+                        str(i),
+                        "ray",
+                        "start",
+                        "--address",
+                        args.ray_address,
+                        "--num-cpus",
+                        str(cpu_count_per_socket),
+                        "--memory",
+                        str(memory_per_socket),
+                    ],
+                    check=True,
+                )
     else:
-        subprocess.run(
-            [
-                "ray",
-                "start",
-                "--address",
-                args.ray_address,
-                "--num-cpus",
-                str(cpu_count),
-            ],
-            check=True,
-        )
+        start_ray_worker(args.ray_address, cpu_count)
 
     # keep printing logs
     while True:

--- a/tests/test_numa.py
+++ b/tests/test_numa.py
@@ -1,0 +1,44 @@
+import sys
+from types import SimpleNamespace
+
+from smallpond.execution import numa as numa_utils
+
+
+def test_running_on_wsl_detects_wsl_kernel(monkeypatch):
+    monkeypatch.setattr(numa_utils.sys, "platform", "linux")
+    monkeypatch.setattr(
+        numa_utils.platform,
+        "uname",
+        lambda: SimpleNamespace(release="5.15.167.4-microsoft-standard-WSL2"),
+    )
+
+    assert numa_utils.running_on_wsl()
+    assert numa_utils.get_numa_node_count() == 1
+
+
+def test_get_numa_node_count_returns_one_on_macos(monkeypatch):
+    monkeypatch.setattr(numa_utils.sys, "platform", "darwin")
+
+    assert numa_utils.get_numa_node_count() == 1
+
+
+def test_get_numa_node_count_clamps_zero_linux_count(monkeypatch):
+    fake_numa = SimpleNamespace(
+        info=SimpleNamespace(get_num_configured_nodes=lambda: 0)
+    )
+    monkeypatch.setattr(numa_utils.sys, "platform", "linux")
+    monkeypatch.setattr(numa_utils, "running_on_wsl", lambda: False)
+    monkeypatch.setitem(sys.modules, "numa", fake_numa)
+
+    assert numa_utils.get_numa_node_count() == 1
+
+
+def test_get_numa_node_count_uses_linux_numa_count(monkeypatch):
+    fake_numa = SimpleNamespace(
+        info=SimpleNamespace(get_num_configured_nodes=lambda: 4)
+    )
+    monkeypatch.setattr(numa_utils.sys, "platform", "linux")
+    monkeypatch.setattr(numa_utils, "running_on_wsl", lambda: False)
+    monkeypatch.setitem(sys.modules, "numa", fake_numa)
+
+    assert numa_utils.get_numa_node_count() == 4


### PR DESCRIPTION
﻿## Summary

- Add a shared NUMA helper that treats WSL2 and macOS as single-node NUMA environments.
- Clamp a Linux NUMA probe result of `0` to `1`, avoiding division-by-zero failures in `RuntimeContext`.
- Reuse the helper in the worker `--bind_numa_node` path while preserving the existing `numactl` behavior for multi-NUMA Linux hosts.
- Add focused tests for WSL2 detection, macOS fallback, zero-count clamping, and normal Linux multi-NUMA counts.

Fixes #16.

## Validation

- `python -m pytest tests/test_numa.py -q --noconftest`
- `python -m compileall -q smallpond tests\test_numa.py`

Note: `python -m pytest tests/test_numa.py -q` is blocked in this local Windows environment because `tests/conftest.py` imports Ray and the project runtime dependencies are not installed here.
