### PR TITLE
fix: check DataFrame task object refs

### DIFF
--- a/smallpond/dataframe.py
+++ b/smallpond/dataframe.py
@@ -239,8 +239,12 @@ class DataFrame:
         """
         Check if the data is ready on disk.
         """
-        if tasks := self.session._node_to_tasks.get(self.plan):
-            _, unready_tasks = ray.wait(tasks, timeout=0)
+        plan = self.optimized_plan or self.plan
+        if tasks := self.session._node_to_tasks.get(plan):
+            dataset_refs = [task._dataset_ref for task in tasks if task._dataset_ref is not None]
+            if len(dataset_refs) != len(tasks):
+                return False
+            _, unready_tasks = ray.wait(dataset_refs, timeout=0)
             return len(unready_tasks) == 0
         return False
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -131,6 +131,15 @@ def test_count(sp: Session):
     assert df.count() == 3
 
 
+def test_is_computed_after_compute(sp: Session):
+    df = sp.from_items([1, 2, 3])
+    assert not df.is_computed()
+
+    df.compute()
+
+    assert df.is_computed()
+
+
 def test_limit(sp: Session):
     df = sp.from_items(list(range(1000))).repartition(10, by_rows=True)
     assert df.limit(2).count() == 2


### PR DESCRIPTION
﻿## Summary

- Fix `DataFrame.is_computed()` to check the optimized plan key used when tasks are created.
- Wait on each task's Ray ObjectRef (`_dataset_ref`) instead of passing Task objects to `ray.wait`.
- Return `False` while tasks exist but have not been submitted yet.
- Add a regression test that verifies `is_computed()` becomes true after `compute()`.

## Why

`DataFrame._compute()` stores execution tasks under `self.optimized_plan` and each task exposes a Ray ObjectRef through `_dataset_ref`. The previous `is_computed()` lookup used the original plan and passed Task instances directly to `ray.wait`, so it could either keep returning `False` after compute or call Ray with invalid inputs.

## Validation

- `python -m compileall -q smallpond tests\test_dataframe.py`
- `git diff --check`

Attempted but blocked locally on Windows:

- `python -m pytest tests/test_dataframe.py::test_is_computed_after_compute -q`

The pytest run fails during import because `smallpond.execution.task` imports the Linux-only `resource` module. This repository is Linux-oriented; the added regression test should run in the normal Linux CI/dev environment.
